### PR TITLE
Changes to make file compile for Xcode 9.2

### DIFF
--- a/SwiftDigest/MD5Digest.swift
+++ b/SwiftDigest/MD5Digest.swift
@@ -104,10 +104,9 @@ public extension String.UTF8View {
 fileprivate struct MD5State {
 
     var a = UInt32(0x67452301)
-    var b = UInt32(0xefcdab89)
-    var c = UInt32(0x98badcfe)
+    var b = UInt32(0x70000000) + UInt32(0x7fcdab89) // 0xefcdab89
+    var c = UInt32(0x40000000) + UInt32(0x58badcfe) // 0x98badcfe
     var d = UInt32(0x10325476)
-
     static let chunkSize = 64
     static let endOfMessageMarker: UInt8 = 0x80
 

--- a/SwiftDigest/MD5Digest.swift
+++ b/SwiftDigest/MD5Digest.swift
@@ -107,6 +107,7 @@ fileprivate struct MD5State {
     var b = UInt32(0x70000000) + UInt32(0x7fcdab89) // 0xefcdab89
     var c = UInt32(0x40000000) + UInt32(0x58badcfe) // 0x98badcfe
     var d = UInt32(0x10325476)
+
     static let chunkSize = 64
     static let endOfMessageMarker: UInt8 = 0x80
 


### PR DESCRIPTION
Xcode 9.2 refuses to file unsigned 32 bit ints with high bit set, so split bit constants into two parts and add them.