### PR TITLE
Fix deprecation warning

### DIFF
--- a/SwiftDigest/MD5Digest.swift
+++ b/SwiftDigest/MD5Digest.swift
@@ -147,8 +147,8 @@ fileprivate struct MD5State {
     @inline(__always) @discardableResult
     private mutating func feedFullChunks(in message: Data) -> Int {
         let chunkCount = message.count / MD5State.chunkSize
-        message.withUnsafeBytes { (pointer: UnsafePointer<UInt32>) -> Void in
-            var cursor = pointer
+        message.withUnsafeBytes { (bufferPointer) -> Void in
+            guard var cursor = bufferPointer.bindMemory(to: UInt32.self).baseAddress else { return }
             for _ in 0 ..< chunkCount {
                 feed(chunkPointer: &cursor)
             }


### PR DESCRIPTION
This eliminates the deprecation warning I get with Xcode 11.5. Passes tests for me. I'm unsure if the `guard` clause is appropriate, or if it should just be a force-unwrap.